### PR TITLE
Revert "Update dependency containerd/containerd to v1.7.25"

### DIFF
--- a/ansible/roles/k8s_cluster/vars/main.yaml
+++ b/ansible/roles/k8s_cluster/vars/main.yaml
@@ -1,7 +1,7 @@
 ---
 k8s_version: "1.32.0"
 # https://containerd.io/releases/#kubernetes-support
-containerd_version: "1.7.25"
+containerd_version: "1.7.24"
 
 upgrade_cluster: false
 


### PR DESCRIPTION
Reverts C0nsultant/homelab-as-code#41

Still not available [upstream](https://download.docker.com/linux/ubuntu/dists/noble/pool/stable/amd64/)